### PR TITLE
Campeões e títulos (atlética)

### DIFF
--- a/src/atletica.tex
+++ b/src/atletica.tex
@@ -97,7 +97,8 @@ conquistas que virão esse ano:
     2015 & Futsal Masculino\\
     2016 & Vôlei Masculino\\
     2017 & Xadrez, Rugby Misto e Rugby Feminino (IME+EFEE)\\
-    2018 & VEM, BIXOS!\\
+    2018 & Xadrez, Futebol de Campo F.\\
+    2019 & VEM BIXES!
     \hline
   \end{tabular}
 \end{center}
@@ -197,7 +198,8 @@ abaixo algumas de nossas conquistas:
     2009 & Copa USP       & Handebol Masc.  & 1º\\
     2012 & Copa USP       & Handebol Masc.  & 2º\\
     2016 & IMEACHECA      & Handebol Masc.  & 2º\\
-    2018 & Copa USP       & Baseball Fem.   & 2º\\
+    2018 & Jogos da Liga  & Handebol Masc.  & 2º\\
+    2017 & Copa USP       & Baseball Fem.   & 2º\\
     2011 & BOBPAI         & Baseball        & 1º\\
     2016 & BOBPAI         & Baseball        & 2º\\
     2016 & Liga Paulista  & Baseball        & 3º\\
@@ -214,21 +216,25 @@ abaixo algumas de nossas conquistas:
     2012 & Copa USP       & Basquete Fem.   & 3º\\
     2014 & Interfarofa    & Futsal Fem.     & 1º\\
     2015 & NDU            & Futsal Fem.     & 2º\\
-    2018 & Copa USP       & Futsal Fem.     & 1º\\
-    2018 & Jogos da Liga  & Futsal Fem.     & 2º\\
-    2018 & NDU            & Vôlei Masc.     & 1º\\
-    2016 & IMEACHCA       & Futsal Fem.     & 1º\\
+    2017 & Copa USP       & Futsal Fem.     & 1º\\
+    2017 & Jogos da Liga  & Futsal Fem.     & 2º\\
+    2017 & IMEACHCA       & Futsal Fem.     & 1º\\
     2015 & Camp. G-4      & Vôlei Masc.     & 2º\\
     2016 & Copa USP       & Vôlei Masc.     & 1º\\
-    2018 & Copa USP       & Vôlei Masc.     & 2º\\
+    2017 & Copa USP       & Vôlei Masc.     & 2º\\
+    2017 & NDU            & Vôlei Masc.     & 1º\\
+    2018 & Copa USP       & Vôlei Masc.     & 1º\\
+    2018 & BIFE           & Vôlei Masc.     & 2º\\
+    2018 & NDU            & Vôlei Masc.    & 2º\\
     2015 & Camp. G-4      & Handebol Fem.   & 1º\\
     2015 & Integramix     & Handebol Fem.   & 1º\\
     2016 & CUPA           & Handebol Fem.   & 2º\\
     2016 & Interfarofa    & Handebol Fem    & 1º\\
+    2018 & Copa USP       & Handebol Fem.   & 1º\\
     2009 & Intercalouros  & Atletismo       & 1º\\
     2011 & LUPAA          & Atletismo       & 1º\\
     2015 & Integramix     & Futebol Campo   & 1º\\
-    2018 & Copa USP       & Futebol Campo M & 1º\\
+    2017 & Copa USP       & Futebol Campo M & 1º\\
     2011 & Copa USP       & Futsal Masc.    & 1º\\
     2012 & Copa Camp      & Futsal Masc.    & 1º\\
     2013 & NDU            & Futsal Masc.    & 1º\\
@@ -237,13 +243,19 @@ abaixo algumas de nossas conquistas:
     2015 & NDU            & Futsal Masc.    & 2º\\
     2016 & IMEACHECA      & Vôlei Fem.      & 1º\\
     2016 & Gran Prix USP  & Vôlei Fem.      & 3º\\
-    2018 & Gran Prix USP  & Vôlei Fem.      & 3º\\
-    2018 & Copa USP       & Jiu-jitsu       & 2º\\
-    2018 & Jogos da Liga  & Tênis Campo M   & 2º\\
-    2018 & NDU            & Xadrez          & 1º\\
-    2018 & Copa USP       & Xadrez          & 3º\\
-    2018 & Jogos da Liga  & Xadrez          & 2º\\
-    2018 & TUES           & Hearthstone     & 2º
+    2017 & Gran Prix USP  & Vôlei Fem.      & 3º\\
+    2017 & Copa USP       & Jiu-jitsu       & 2º\\
+    2017 & Jogos da Liga  & Tênis Campo M   & 2º\\
+    2017 & NDU            & Xadrez          & 1º\\
+    2017 & Copa USP       & Xadrez          & 3º\\
+    2017 & Jogos da Liga  & Xadrez          & 2º\\
+    2017 & TUES           & Hearthstone     & 2º\\
+    2018 & BIFE           & Basquete Masc.  & 1º\\
+    2018 & Jogos da Liga  & Basquete Masc.  & 2º\\
+    2018 & BIFE           & Natação Masc.   & 2º\\
+    2018 & Jogos da Liga  & Natação Masc.   & 2º\\
+    2018 & BIFE           & Rugby Masc.     & 2º\\
+    2018 & BIFE           & Futebol Campo F.& 2º
   \end{tabular}
 \end{center}
 


### PR DESCRIPTION
- Muda os "2018" que estavam no guia de 2018 por "2017" (não há conquistas/títulos de 2017 e acho que não faz muito sentido já ter conquistas de 2018 no início de 2018; vou ver se está certo)

Segundo e-mail da Ana, atualiza:
- Modalidade e campeões do Bichusp
- Conquistas/Títulos de 2018